### PR TITLE
Added php5-intl to the list of PHP packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN \
  /usr/sbin/update-locale LANG=en_US.UTF-8 &&\
  echo "mysql-server mysql-server/root_password password root" | debconf-set-selections &&\
  echo "mysql-server mysql-server/root_password_again password root" | debconf-set-selections &&\
- apt-get -y --no-install-recommends install ca-certificates git php5-mysqlnd php5-cli php5-sqlite php5-mcrypt php5-curl php-gettext php5-gd php5-imagick php5-xdebug imagemagick openssh-client wget curl software-properties-common gettext zip mysql-server mysql-client apt-transport-https ruby python python3 perl &&\
+ apt-get -y --no-install-recommends install ca-certificates git php5-mysqlnd php5-cli php5-sqlite php5-mcrypt php5-curl php5-intl php-gettext php5-gd php5-imagick php5-xdebug imagemagick openssh-client wget curl software-properties-common gettext zip mysql-server mysql-client apt-transport-https ruby python python3 perl &&\
  curl -sL https://deb.nodesource.com/setup_4.x | bash - &&\
  apt-get -y --no-install-recommends install nodejs &&\
  apt-get autoclean && apt-get clean && apt-get autoremove


### PR DESCRIPTION
Many PHP tools require this extension to work.  For example,
CakePHP framework, in its 3rd version.
